### PR TITLE
feat: prauto worktree directory change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ helm-charts/dataspoke/charts/
 memory/
 .prauto/config.local.env
 .prauto/state/
+.prauto/worktrees/

--- a/.prauto/lib/git-ops.sh
+++ b/.prauto/lib/git-ops.sh
@@ -9,7 +9,7 @@
 create_branch() {
   local issue_number="$1"
   BRANCH_NAME="${PRAUTO_BRANCH_PREFIX}I-${issue_number}"
-  WORKTREE_DIR="/tmp/prauto-I-${issue_number}"
+  WORKTREE_DIR="${PRAUTO_DIR}/worktrees/I-${issue_number}"
 
   info "Fetching from origin..."
   git fetch origin 2>/dev/null || warn "git fetch failed — continuing with local refs."
@@ -41,7 +41,7 @@ create_branch() {
 checkout_branch_worktree() {
   local branch="$1"
   local safe_name="${branch//\//-}"
-  WORKTREE_DIR="/tmp/prauto-${safe_name}"
+  WORKTREE_DIR="${PRAUTO_DIR}/worktrees/${safe_name}"
 
   info "Fetching origin/${branch}..."
   git fetch origin "$branch" 2>/dev/null || warn "git fetch failed for ${branch}."

--- a/.prauto/lib/state.sh
+++ b/.prauto/lib/state.sh
@@ -10,7 +10,7 @@ SESSIONS_DIR="${STATE_DIR}/sessions"
 
 # Ensure state directories exist.
 ensure_state_dirs() {
-  mkdir -p "$STATE_DIR" "$HISTORY_DIR" "$SESSIONS_DIR"
+  mkdir -p "$STATE_DIR" "$HISTORY_DIR" "$SESSIONS_DIR" "${PRAUTO_DIR}/worktrees"
 }
 
 # Acquire PID-based lock. Returns 0 on success, 1 if already locked.


### PR DESCRIPTION
## Summary

Automated implementation for #5.
Generated by `prauto(prauto-01)` using Claude Code CLI.

## Changes

```
feb8401 feat: move prauto worktrees from /tmp to .prauto/worktrees/
```

## Test plan

- [ ] Review automated changes
- [ ] Verify tests pass in CI
- [ ] Check spec compliance

---
*Generated by prauto -- autonomous PR worker*