### PR TITLE
docs: propagate TESTING.md cross-references across docs and agent configs

### DIFF
--- a/.claude/agents/backend.md
+++ b/.claude/agents/backend.md
@@ -43,7 +43,7 @@ src/
 - **Temporal** — `temporalio` SDK for workflows and activities in `src/workflows/`
 - **Dependency injection** — FastAPI `Depends()` for services, DB sessions, auth
 - **async/await** — `async def` for all I/O-bound operations
-- **Testing** — `pytest` + `pytest-asyncio`; mock DataHub calls in unit tests; never hit real DataHub in tests
+- **Testing** — `pytest` + `pytest-asyncio`; mock DataHub calls in unit tests; never hit real DataHub in tests. For directory layout, mocking rules, and the integration-test dev-env lock protocol, see `spec/TESTING.md`.
 
 ## DataHub integration patterns
 

--- a/.claude/agents/frontend.md
+++ b/.claude/agents/frontend.md
@@ -51,3 +51,4 @@ src/frontend/
 ## After completing a task
 
 Run `npm test` (or the relevant test subset) and `npx tsc --noEmit` to verify your changes before reporting completion.
+For test naming conventions and mocking rules, see `spec/TESTING.md`.

--- a/.claude/skills/plan-doc/SKILL.md
+++ b/.claude/skills/plan-doc/SKILL.md
@@ -16,6 +16,8 @@ spec/
 │                                 shared services, deployment. Conforms to MANIFESTO.
 ├── USE_CASE_en.md / _kr.md    ← Conceptual scenarios (UC1–UC8) by user group.
 ├── AI_SCAFFOLD.md             ← Goal 2: Claude Code scaffold conventions.
+├── TESTING.md                 ← Testing conventions: toolchain, unit/integration/E2E
+│                                 workflows, Imazon test data.
 ├── DATAHUB_INTEGRATION.md     ← DataHub SDK patterns, aspect catalog, GraphQL,
 │                                 event subscription, error handling.
 ├── API_DESIGN_PRINCIPLE_en.md / _kr.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Specs must not contradict each other — propagate changes up and down. Priority
 |----------|-----------|------|
 | 1 | `MANIFESTO_en/kr.md` | Product identity. Never modify unless explicitly requested. |
 | 2 | `API_DESIGN_PRINCIPLE_en/kr.md`, `DATAHUB_INTEGRATION.md` | Binding conventions. |
-| 3 | `ARCHITECTURE.md`, `USE_CASE_en/kr.md` | System architecture and scenarios. |
+| 3 | `ARCHITECTURE.md`, `TESTING.md`, `USE_CASE_en/kr.md` | System architecture, testing conventions, and scenarios. |
 | 4 | `AI_SCAFFOLD.md` | Claude Code scaffold conventions. |
 | 5 | `feature/<FEATURE>.md` | Common feature specs. |
 | 6 | `feature/spoke/<FEATURE>.md` | User-group-specific feature specs. |
@@ -57,6 +57,7 @@ For end-to-end feature implementation, use subagents in this order:
 
 Each agent reads the spec and the output of previous agents as context.
 For spec authoring, use `/dataspoke-plan-write` or `/plan-doc` directly.
+For testing conventions (unit/integration/E2E, toolchain, dev-env lock protocol), see `spec/TESTING.md`.
 
 ## Testing prauto
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ See [`spec/feature/DEV_ENV.md`](spec/feature/DEV_ENV.md) for the full variable l
 | [spec/feature/API.md](spec/feature/API.md) | API layer design: routes, auth, middleware, error codes |
 | [spec/feature/DEV_ENV.md](spec/feature/DEV_ENV.md) | Dev environment specification |
 | [spec/feature/HELM_CHART.md](spec/feature/HELM_CHART.md) | Helm chart specification for production deployment |
+| [spec/TESTING.md](spec/TESTING.md) | Testing conventions: toolchain, unit/integration/E2E workflow, dev-env lock protocol |
 
 ## License
 

--- a/spec/AI_SCAFFOLD.md
+++ b/spec/AI_SCAFFOLD.md
@@ -156,6 +156,7 @@ Documents authored so far (use `/dataspoke-plan-write` to add more):
 |------|----------|-------------|
 | Top-level | `spec/MANIFESTO_en.md`, `spec/MANIFESTO_kr.md` | Product identity, user-group taxonomy (DE/DA/DG). Highest authority |
 | Top-level | `spec/ARCHITECTURE.md` | System-wide architecture, components, tech stack, feature mapping (UC1–UC8) |
+| Top-level | `spec/TESTING.md` | Testing conventions: toolchain, unit/integration/E2E patterns, Imazon test data design |
 | Top-level | `spec/AI_SCAFFOLD.md` | This document — Claude Code scaffold conventions |
 | Top-level | `spec/USE_CASE_en.md`, `spec/USE_CASE_kr.md` | Conceptual scenarios by user group (UC1–UC8) |
 | Top-level | `spec/DATAHUB_INTEGRATION.md` | DataHub SDK patterns, aspect catalog, error handling |

--- a/spec/ARCHITECTURE.md
+++ b/spec/ARCHITECTURE.md
@@ -430,6 +430,8 @@ Shared by all features.
 | Container Runtime | Docker |
 | Orchestrator | Kubernetes + Helm |
 
+For full testing conventions, toolchain configuration, mocking rules, and the integration test lock protocol, see [`spec/TESTING.md`](TESTING.md).
+
 ---
 
 ## Deployment Architecture


### PR DESCRIPTION
## Summary

Automated implementation for #10.
Generated by `prauto(prauto-01)` using Claude Code CLI.

## Changes

```
3952322 docs: propagate spec/TESTING.md cross-references to README, CLAUDE.md, ARCHITECTURE, AI_SCAFFOLD, and .claude utilities
```

## Test plan

- [ ] Review automated changes
- [ ] Verify tests pass in CI
- [ ] Check spec compliance

---
*Generated by prauto -- autonomous PR worker*