### PR TITLE
feat: implement DataHub pass-through proxy and audit response-format compliance

### DIFF
--- a/src/api/routers/hub.py
+++ b/src/api/routers/hub.py
@@ -1,6 +1,15 @@
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+"""DataHub pass-through proxy routes.
+
+Forwards requests to DataHub GMS without wrapping responses — clients
+receive DataHub's native JSON/GraphQL payloads.
+"""
+
+import httpx
+from fastapi import APIRouter, Depends, Request, Response
 
 from src.api.auth.dependencies import require_common
+from src.api.config import settings
+from src.shared.exceptions import DataHubUnavailableError
 
 router = APIRouter(
     prefix="/hub",
@@ -8,19 +17,102 @@ router = APIRouter(
     dependencies=[Depends(require_common)],
 )
 
-_501 = HTTPException(
-    status_code=status.HTTP_501_NOT_IMPLEMENTED,
-    detail="DataHub pass-through proxy is not yet implemented.",
+_PROXY_TIMEOUT = 30.0
+
+# Headers that must not be forwarded between hops (RFC 2616 §13.5.1).
+_HOP_BY_HOP = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailers",
+        "transfer-encoding",
+        "upgrade",
+        "host",
+    }
 )
 
 
+def _build_upstream_headers(request: Request) -> dict[str, str]:
+    """Build headers for the upstream DataHub request.
+
+    Strips hop-by-hop headers and the caller's Authorization (DataSpoke auth
+    is already validated).  Injects the DataHub service token when configured.
+    """
+    headers = {
+        k: v
+        for k, v in request.headers.items()
+        if k.lower() not in _HOP_BY_HOP and k.lower() != "authorization"
+    }
+    if settings.datahub_token:
+        headers["authorization"] = f"Bearer {settings.datahub_token}"
+    return headers
+
+
+def _filter_response_headers(response: httpx.Response) -> dict[str, str]:
+    """Return only safe response headers (drop hop-by-hop)."""
+    return {k: v for k, v in response.headers.items() if k.lower() not in _HOP_BY_HOP}
+
+
+async def _proxy(
+    method: str,
+    url: str,
+    *,
+    headers: dict[str, str],
+    content: bytes,
+    params: str,
+) -> Response:
+    """Send request to DataHub and return the raw response."""
+    target = f"{url}?{params}" if params else url
+    try:
+        async with httpx.AsyncClient(timeout=_PROXY_TIMEOUT) as client:
+            resp = await client.request(
+                method,
+                target,
+                content=content,
+                headers=headers,
+            )
+    except (httpx.ConnectError, httpx.TimeoutException) as exc:
+        raise DataHubUnavailableError(f"DataHub GMS unreachable: {exc}") from exc
+
+    return Response(
+        content=resp.content,
+        status_code=resp.status_code,
+        headers=_filter_response_headers(resp),
+    )
+
+
 @router.post("/graphql")
-async def hub_graphql(_request: Request) -> None:
-    # TODO: proxy to DATASPOKE_DATAHUB_GMS_URL/api/graphql
-    raise _501
+async def hub_graphql(request: Request) -> Response:
+    """Proxy GraphQL queries to DataHub GMS."""
+    body = await request.body()
+    headers = _build_upstream_headers(request)
+    headers["content-type"] = "application/json"
+
+    return await _proxy(
+        "POST",
+        f"{settings.datahub_gms_url}/api/graphql",
+        headers=headers,
+        content=body,
+        params="",
+    )
 
 
-@router.api_route("/openapi/{path:path}", methods=["GET", "POST", "PUT", "PATCH", "DELETE"])
-async def hub_openapi(_request: Request, path: str) -> None:
-    # TODO: proxy to DATASPOKE_DATAHUB_GMS_URL/openapi/{path}
-    raise _501
+@router.api_route(
+    "/openapi/{path:path}",
+    methods=["GET", "POST", "PUT", "PATCH", "DELETE"],
+)
+async def hub_openapi(request: Request, path: str) -> Response:
+    """Proxy REST requests to DataHub GMS OpenAPI surface."""
+    body = await request.body()
+    headers = _build_upstream_headers(request)
+
+    return await _proxy(
+        request.method,
+        f"{settings.datahub_gms_url}/openapi/{path}",
+        headers=headers,
+        content=body,
+        params=request.url.query,
+    )

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -111,6 +111,20 @@ def _get_datahub_session_token() -> str:
     return data.get("data", {}).get("token", "")
 
 
+def _resolve_datahub_token() -> str:
+    """Return a valid DataHub token, falling back to session login.
+
+    Mirrors the fallback logic used by the ``datahub_client`` fixture so that
+    hub-proxy tests can inject a working token into the mocked settings.
+    """
+    if _datahub_token:
+        return _datahub_token
+    try:
+        return _get_datahub_session_token()
+    except Exception:
+        return ""
+
+
 def _auth_headers() -> dict[str, str]:
     """Create JWT auth headers for integration test requests."""
     from src.api.auth.jwt import create_access_token

--- a/tests/integration/test_hub_proxy_integration.py
+++ b/tests/integration/test_hub_proxy_integration.py
@@ -1,0 +1,93 @@
+"""Integration tests for hub proxy against real DataHub GMS.
+
+Prerequisites:
+- DataHub GMS port-forwarded to localhost:9004
+"""
+
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from .conftest import _auth_headers, _datahub_gms_url, _resolve_datahub_token
+
+
+@pytest_asyncio.fixture
+async def http_client():
+    """HTTP client with settings patched to point at dev-env DataHub."""
+    from src.api.main import app
+
+    token = _resolve_datahub_token()
+    if not token:
+        pytest.skip("Cannot obtain DataHub token (frontend unreachable)")
+
+    with patch("src.api.routers.hub.settings") as mock_settings:
+        mock_settings.datahub_gms_url = _datahub_gms_url
+        mock_settings.datahub_token = token
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            yield client
+
+
+_HEADERS = _auth_headers()
+_GRAPHQL_URL = "/api/v1/hub/graphql"
+_OPENAPI_BASE = "/api/v1/hub/openapi"
+
+
+@pytest.mark.asyncio
+async def test_graphql_proxy_queries_datahub(http_client):
+    resp = await http_client.post(
+        _GRAPHQL_URL,
+        json={"query": "{ listDatasets(input: {start: 0, count: 1}) { total datasets { urn } } }"},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "data" in body
+
+
+@pytest.mark.asyncio
+async def test_graphql_proxy_returns_datahub_errors(http_client):
+    resp = await http_client.post(
+        _GRAPHQL_URL,
+        json={"query": "{ invalidField }"},
+        headers=_HEADERS,
+    )
+    # DataHub returns 200 with errors array for invalid GraphQL
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "errors" in body
+
+
+@pytest.mark.asyncio
+async def test_openapi_proxy_list_entities(http_client):
+    resp = await http_client.get(
+        f"{_OPENAPI_BASE}/v3/entity/dataset",
+        headers=_HEADERS,
+        params={"count": 1},
+    )
+    # DataHub v3 entity API returns 200
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_openapi_proxy_404_for_unknown_entity(http_client):
+    resp = await http_client.get(
+        f"{_OPENAPI_BASE}/v3/entity/dataset/urn%3Ali%3Adataset%3A(urn%3Ali%3AdataPlatform%3Anone,nonexistent.table,PROD)",
+        headers=_HEADERS,
+    )
+    # DataHub returns 404 for non-existent entities
+    assert resp.status_code in (400, 404)
+
+
+@pytest.mark.asyncio
+async def test_hub_auth_required(http_client):
+    resp = await http_client.post(
+        _GRAPHQL_URL,
+        json={"query": "{ __typename }"},
+    )
+    assert resp.status_code == 401

--- a/tests/integration/test_response_format_integration.py
+++ b/tests/integration/test_response_format_integration.py
@@ -1,0 +1,170 @@
+"""End-to-end response format smoke tests.
+
+Hits each major router via HTTP and verifies response format compliance
+(snake_case fields, pagination envelope, resp_time, error envelope).
+
+Prerequisites:
+- All dev-env port-forwards active (DataHub, PostgreSQL, Redis, Qdrant)
+- Dummy data ingested via conftest.py
+"""
+
+import re
+from unittest.mock import patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from .conftest import _auth_headers, _datahub_gms_url, _resolve_datahub_token
+
+DUMMY_DATA_SCHEMAS: frozenset[str] = frozenset(
+    {"ontology", "ingestion", "validation", "generation"}
+)
+
+_HEADERS = _auth_headers()
+_CAMEL_RE = re.compile(r"[a-z][A-Z]")
+
+
+@pytest_asyncio.fixture
+async def http_client(datahub_client, redis_client, async_session):
+    """HTTP client with real DI providers pointing to dev-env infra."""
+    from src.api.dependencies import get_datahub, get_db, get_redis
+    from src.api.main import app
+
+    app.dependency_overrides[get_datahub] = lambda: datahub_client
+    app.dependency_overrides[get_redis] = lambda: redis_client
+
+    async def _override_db():
+        yield async_session
+
+    app.dependency_overrides[get_db] = _override_db
+
+    # Also patch hub proxy settings for DataHub pass-through tests
+    hub_token = _resolve_datahub_token()
+    with patch("src.api.routers.hub.settings") as mock_settings:
+        mock_settings.datahub_gms_url = _datahub_gms_url
+        mock_settings.datahub_token = hub_token if hub_token else ""
+
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://testserver",
+        ) as client:
+            yield client
+
+    app.dependency_overrides.clear()
+
+
+def _assert_snake_case_keys(data: dict | list, path: str = "") -> None:
+    """Recursively assert all dict keys are snake_case."""
+    if isinstance(data, dict):
+        for key, value in data.items():
+            full_path = f"{path}.{key}" if path else key
+            assert not _CAMEL_RE.search(key), f"camelCase key found: {full_path}"
+            _assert_snake_case_keys(value, full_path)
+    elif isinstance(data, list):
+        for i, item in enumerate(data):
+            _assert_snake_case_keys(item, f"{path}[{i}]")
+
+
+def _assert_pagination_envelope(body: dict) -> None:
+    """Assert response has pagination fields."""
+    assert "offset" in body, "Missing 'offset'"
+    assert "limit" in body, "Missing 'limit'"
+    assert "total_count" in body, "Missing 'total_count'"
+    assert "resp_time" in body, "Missing 'resp_time'"
+
+
+def _assert_single_response(body: dict) -> None:
+    """Assert response has resp_time."""
+    assert "resp_time" in body, "Missing 'resp_time'"
+
+
+def _assert_error_envelope(body: dict) -> None:
+    """Assert error response has required fields."""
+    assert "error_code" in body, "Missing 'error_code'"
+    assert "message" in body, "Missing 'message'"
+    assert "trace_id" in body, "Missing 'trace_id'"
+
+
+# ── Ontology ──────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ontology_list_response_format(http_client):
+    resp = await http_client.get("/api/v1/spoke/common/ontology", headers=_HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    _assert_pagination_envelope(body)
+    assert "concepts" in body
+    _assert_snake_case_keys(body)
+
+
+# ── Ingestion ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ingestion_list_response_format(http_client):
+    resp = await http_client.get("/api/v1/spoke/common/ingestion", headers=_HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    _assert_pagination_envelope(body)
+    assert "configs" in body
+    _assert_snake_case_keys(body)
+
+
+# ── Validation ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_validation_list_response_format(http_client):
+    resp = await http_client.get("/api/v1/spoke/common/validation", headers=_HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    _assert_pagination_envelope(body)
+    assert "configs" in body
+    _assert_snake_case_keys(body)
+
+
+# ── Generation ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_gen_list_response_format(http_client):
+    resp = await http_client.get("/api/v1/spoke/common/gen", headers=_HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+    _assert_pagination_envelope(body)
+    assert "configs" in body
+    _assert_snake_case_keys(body)
+
+
+# ── Error response ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_error_response_format(http_client):
+    fake_urn = "urn:li:dataset:(urn:li:dataPlatform:none,does.not.exist,PROD)"
+    resp = await http_client.get(
+        f"/api/v1/spoke/common/data/{fake_urn}",
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 404
+    body = resp.json()
+    _assert_error_envelope(body)
+
+
+# ── Hub GraphQL (raw pass-through — no envelope) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hub_graphql_response_format(http_client):
+    resp = await http_client.post(
+        "/api/v1/hub/graphql",
+        json={"query": "{ listDatasets(input: {start: 0, count: 1}) { total } }"},
+        headers=_HEADERS,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    # Hub proxy returns raw DataHub response — must NOT have resp_time envelope
+    assert "resp_time" not in body
+    assert "data" in body

--- a/tests/unit/api/test_hub_proxy.py
+++ b/tests/unit/api/test_hub_proxy.py
@@ -1,0 +1,230 @@
+"""Unit tests for the DataHub pass-through proxy routes."""
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from httpx import AsyncClient
+
+from tests.unit.api.conftest import auth_headers
+
+_DE_HEADERS = auth_headers(groups=["de"])
+_GRAPHQL_URL = "/api/v1/hub/graphql"
+_OPENAPI_BASE = "/api/v1/hub/openapi"
+
+
+def _mock_response(
+    status_code: int = 200,
+    content: bytes = b'{"data": "ok"}',
+    headers: dict[str, str] | None = None,
+) -> httpx.Response:
+    """Build a fake httpx.Response."""
+    return httpx.Response(
+        status_code=status_code,
+        content=content,
+        headers=headers or {"content-type": "application/json"},
+    )
+
+
+# ── GraphQL proxy ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_graphql_proxy_forwards_request(client: AsyncClient) -> None:
+    mock_resp = _mock_response(content=b'{"data":{"listDatasets":[]}}')
+    with patch("src.api.routers.hub.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.request.return_value = mock_resp
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        resp = await client.post(
+            _GRAPHQL_URL,
+            content=b'{"query":"{ listDatasets { total } }"}',
+            headers={**_DE_HEADERS, "content-type": "application/json"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"data": {"listDatasets": []}}
+    mock_client.request.assert_called_once()
+    call_kwargs = mock_client.request.call_args
+    assert call_kwargs[0][0] == "POST"
+    assert "/api/graphql" in call_kwargs[0][1]
+
+
+@pytest.mark.asyncio
+async def test_graphql_proxy_forwards_datahub_token(client: AsyncClient) -> None:
+    mock_resp = _mock_response()
+    with (
+        patch("src.api.routers.hub.httpx.AsyncClient") as mock_cls,
+        patch("src.api.routers.hub.settings") as mock_settings,
+    ):
+        mock_settings.datahub_gms_url = "http://gms:8080"
+        mock_settings.datahub_token = "dh-secret-token"
+        mock_client = AsyncMock()
+        mock_client.request.return_value = mock_resp
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        await client.post(
+            _GRAPHQL_URL,
+            content=b"{}",
+            headers=_DE_HEADERS,
+        )
+
+    call_kwargs = mock_client.request.call_args
+    forwarded_headers = call_kwargs[1]["headers"]
+    assert forwarded_headers["authorization"] == "Bearer dh-secret-token"
+
+
+@pytest.mark.asyncio
+async def test_graphql_proxy_handles_datahub_error(client: AsyncClient) -> None:
+    mock_resp = _mock_response(status_code=500, content=b'{"error":"internal"}')
+    with patch("src.api.routers.hub.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.request.return_value = mock_resp
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        resp = await client.post(
+            _GRAPHQL_URL,
+            content=b"{}",
+            headers=_DE_HEADERS,
+        )
+
+    assert resp.status_code == 500
+    assert resp.json() == {"error": "internal"}
+
+
+@pytest.mark.asyncio
+async def test_graphql_proxy_handles_connect_error(client: AsyncClient) -> None:
+    with patch("src.api.routers.hub.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.request.side_effect = httpx.ConnectError("Connection refused")
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        resp = await client.post(
+            _GRAPHQL_URL,
+            content=b"{}",
+            headers=_DE_HEADERS,
+        )
+
+    assert resp.status_code == 502
+    body = resp.json()
+    assert body["error_code"] == "DATAHUB_UNAVAILABLE"
+
+
+@pytest.mark.asyncio
+async def test_graphql_proxy_handles_timeout(client: AsyncClient) -> None:
+    with patch("src.api.routers.hub.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.request.side_effect = httpx.TimeoutException("timed out")
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        resp = await client.post(
+            _GRAPHQL_URL,
+            content=b"{}",
+            headers=_DE_HEADERS,
+        )
+
+    assert resp.status_code == 502
+    body = resp.json()
+    assert body["error_code"] == "DATAHUB_UNAVAILABLE"
+
+
+# ── OpenAPI proxy ─────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_openapi_proxy_get(client: AsyncClient) -> None:
+    mock_resp = _mock_response(content=b'{"entities":[]}')
+    with patch("src.api.routers.hub.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.request.return_value = mock_resp
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        resp = await client.get(
+            f"{_OPENAPI_BASE}/v3/entity/dataset",
+            headers=_DE_HEADERS,
+        )
+
+    assert resp.status_code == 200
+    call_kwargs = mock_client.request.call_args
+    assert call_kwargs[0][0] == "GET"
+    assert "/openapi/v3/entity/dataset" in call_kwargs[0][1]
+
+
+@pytest.mark.asyncio
+async def test_openapi_proxy_post(client: AsyncClient) -> None:
+    mock_resp = _mock_response(status_code=201, content=b'{"urn":"urn:li:dataset:1"}')
+    with patch("src.api.routers.hub.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.request.return_value = mock_resp
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        resp = await client.post(
+            f"{_OPENAPI_BASE}/v3/entity/dataset",
+            content=b'{"aspect":"value"}',
+            headers={**_DE_HEADERS, "content-type": "application/json"},
+        )
+
+    assert resp.status_code == 201
+    call_kwargs = mock_client.request.call_args
+    assert call_kwargs[0][0] == "POST"
+
+
+@pytest.mark.asyncio
+async def test_openapi_proxy_preserves_query_params(client: AsyncClient) -> None:
+    mock_resp = _mock_response()
+    with patch("src.api.routers.hub.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.request.return_value = mock_resp
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        resp = await client.get(
+            f"{_OPENAPI_BASE}/v3/entity/dataset?type=dataset&count=10",
+            headers=_DE_HEADERS,
+        )
+
+    assert resp.status_code == 200
+    call_kwargs = mock_client.request.call_args
+    target_url = call_kwargs[0][1]
+    assert "type=dataset" in target_url
+    assert "count=10" in target_url
+
+
+@pytest.mark.asyncio
+async def test_openapi_proxy_preserves_status_code(client: AsyncClient) -> None:
+    mock_resp = _mock_response(status_code=404, content=b'{"error":"not found"}')
+    with patch("src.api.routers.hub.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.request.return_value = mock_resp
+        mock_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        resp = await client.get(
+            f"{_OPENAPI_BASE}/v3/entity/dataset/unknown",
+            headers=_DE_HEADERS,
+        )
+
+    assert resp.status_code == 404
+
+
+# ── Auth requirement ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_hub_graphql_requires_auth(client: AsyncClient) -> None:
+    resp = await client.post(_GRAPHQL_URL, content=b"{}")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_hub_openapi_requires_auth(client: AsyncClient) -> None:
+    resp = await client.get(f"{_OPENAPI_BASE}/v3/entity/dataset")
+    assert resp.status_code == 401

--- a/tests/unit/api/test_response_format.py
+++ b/tests/unit/api/test_response_format.py
@@ -1,0 +1,124 @@
+"""Programmatic response-format compliance checks.
+
+Ensures Pydantic schemas follow API.md conventions:
+- All response fields are snake_case
+- All collection responses include pagination envelope
+- All single-item responses include resp_time
+- Error response has required fields
+- No remaining 501 stubs in routers
+"""
+
+import importlib
+import pkgutil
+import re
+
+import pytest
+from pydantic import BaseModel
+
+from src.api.schemas.common import ErrorResponse, PaginatedResponse, SingleResponse
+
+# ── Schema discovery ──────────────────────────────────────────────────────────
+
+_CAMEL_RE = re.compile(r"[a-z][A-Z]")
+
+
+def _discover_response_models() -> list[type[BaseModel]]:
+    """Import all schema modules and collect *Response classes."""
+    import src.api.schemas as schemas_pkg
+
+    models: list[type[BaseModel]] = []
+    for importer, mod_name, _ in pkgutil.walk_packages(
+        schemas_pkg.__path__, prefix=schemas_pkg.__name__ + "."
+    ):
+        mod = importlib.import_module(mod_name)
+        for attr_name in dir(mod):
+            if not attr_name.endswith("Response"):
+                continue
+            cls = getattr(mod, attr_name)
+            if isinstance(cls, type) and issubclass(cls, BaseModel) and cls is not BaseModel:
+                models.append(cls)
+    return list(set(models))
+
+
+_ALL_RESPONSE_MODELS = _discover_response_models()
+
+# Separate into list (paginated) and single-item responses
+_LIST_RESPONSES = [m for m in _ALL_RESPONSE_MODELS if issubclass(m, PaginatedResponse)]
+_SINGLE_RESPONSES = [
+    m
+    for m in _ALL_RESPONSE_MODELS
+    if issubclass(m, SingleResponse)
+    and not issubclass(m, PaginatedResponse)
+    and m is not SingleResponse
+]
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_all_list_responses_have_pagination_fields() -> None:
+    """Every *ListResponse must have offset, limit, total_count, resp_time."""
+    required = {"offset", "limit", "total_count", "resp_time"}
+    for model in _LIST_RESPONSES:
+        fields = set(model.model_fields.keys())
+        missing = required - fields
+        assert not missing, f"{model.__name__} missing pagination fields: {missing}"
+
+
+def test_all_single_responses_have_resp_time() -> None:
+    """Every single-item *Response must have resp_time."""
+    for model in _SINGLE_RESPONSES:
+        assert "resp_time" in model.model_fields, f"{model.__name__} missing resp_time"
+
+
+def test_all_response_fields_are_snake_case() -> None:
+    """No camelCase field names in any response model."""
+    violations: list[str] = []
+    for model in _ALL_RESPONSE_MODELS:
+        for field_name in model.model_fields:
+            if _CAMEL_RE.search(field_name):
+                violations.append(f"{model.__name__}.{field_name}")
+    assert not violations, f"camelCase fields found: {violations}"
+
+
+def test_error_response_has_required_fields() -> None:
+    """ErrorResponse must have error_code, message, trace_id."""
+    fields = set(ErrorResponse.model_fields.keys())
+    assert {"error_code", "message", "trace_id"} <= fields
+
+
+def test_discovered_models_are_not_empty() -> None:
+    """Sanity check: ensure discovery finds a reasonable number of models."""
+    assert len(_ALL_RESPONSE_MODELS) >= 15, (
+        f"Expected at least 15 response models, found {len(_ALL_RESPONSE_MODELS)}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_remaining_501_stubs() -> None:
+    """Verify no router handler raises 501 NOT_IMPLEMENTED."""
+    import src.api.routers as routers_pkg
+
+    for importer, mod_name, _ in pkgutil.walk_packages(
+        routers_pkg.__path__, prefix=routers_pkg.__name__ + "."
+    ):
+        mod = importlib.import_module(mod_name)
+
+    # After importing all routers, check the app's routes
+    from src.api.main import app
+
+    for route in app.routes:
+        endpoint = getattr(route, "endpoint", None)
+        if endpoint is None:
+            continue
+        # Check if the function source contains "raise _501" or "501"
+        import inspect
+
+        try:
+            source = inspect.getsource(endpoint)
+        except (OSError, TypeError):
+            continue
+        assert "HTTP_501_NOT_IMPLEMENTED" not in source, (
+            f"Route endpoint {endpoint.__name__} still contains a 501 stub"
+        )
+        assert "raise _501" not in source, f"Route endpoint {endpoint.__name__} still raises _501"

--- a/tests/unit/api/test_stub_routes.py
+++ b/tests/unit/api/test_stub_routes.py
@@ -40,12 +40,8 @@ COMMON_SEARCH_ROUTES: list[tuple[str, str]] = []
 # ── DG/metric — implemented by MetricsService ────────────────────────────────
 DG_METRIC_ROUTES: list[tuple[str, str]] = []
 
-# ── DG/overview ────────────────────────────────────────────────────────────────
-DG_OVERVIEW_ROUTES = [
-    ("GET", "/api/v1/spoke/dg/overview"),
-    ("GET", "/api/v1/spoke/dg/overview/attr"),
-    ("PATCH", "/api/v1/spoke/dg/overview/attr"),
-]
+# ── DG/overview — implemented by OverviewService ──────────────────────────────
+DG_OVERVIEW_ROUTES: list[tuple[str, str]] = []
 
 
 async def _assert_501(client: AsyncClient, method: str, path: str, headers: dict) -> None:


### PR DESCRIPTION
## Summary

Automated implementation for #35.
Generated by `prauto(prauto01)` using Claude Code CLI.

## Changes

```
db537be fix: resolve DataHub token in hub proxy test fixtures
2e1bdcd feat: implement DataHub pass-through proxy and verify API compliance
```

---
*Generated by prauto -- autonomous PR worker*